### PR TITLE
add all payload generators

### DIFF
--- a/QRCodeGenerator/2.6.0/New-PSOneQRCode.ps1
+++ b/QRCodeGenerator/2.6.0/New-PSOneQRCode.ps1
@@ -59,7 +59,7 @@ function New-PSOneQRCode
         
 
     $generator = New-Object -TypeName QRCoder.QRCodeGenerator
-    $data = $generator.CreateQrCode($payload, 'Q')
+    $data = $generator.CreateQrCode($payload, [QRCoder.QRCodeGenerator+ECCLevel]::Q)
     $code = new-object -TypeName QRCoder.PngByteQRCode -ArgumentList ($data)
     $byteArray = $code.GetGraphic($Width, $darkColorRgba, $lightColorRgba)
     [System.IO.File]::WriteAllBytes($outPath, $byteArray)

--- a/QRCodeGenerator/2.6.0/New-PSOneQRCodeWhatsAppMessage.ps1
+++ b/QRCodeGenerator/2.6.0/New-PSOneQRCodeWhatsAppMessage.ps1
@@ -1,0 +1,58 @@
+﻿function New-PSOneQRCodeWhatsAppMessage
+{
+    <#
+            .SYNOPSIS
+            Creates a QR code graphic containing a Whatsapp Message
+
+            .DESCRIPTION
+            Creates a QR code graphic in png format that - when scanned by a smart device - opens a Whatsapp to send the defined Message
+            
+            .PARAMETER Text
+            The Text to send via WhatsApp
+
+            .PARAMETER Show
+            Opens the generated QR code in associated program
+
+            .PARAMETER OutPath
+            Path to generated png file. When omitted, a temporary file name is used.
+
+            .EXAMPLE
+            New-PSOneQRCodeWhatsAppMessage -Text "Check out the following link: https://github.com/TobiasPSP/Modules.QRCodeGenerator" -Width 200 -Show -OutPath "$home\Desktop\qr.png"
+            Creates a QR code png graphics on your desktop, and opens it with the associated program
+
+            .NOTES
+            Compatible with all PowerShell versions including PowerShell 6/Core
+            Uses binaries from https://github.com/codebude/QRCoder/wiki
+
+            .LINK
+            https://github.com/TobiasPSP/Modules.QRCodeGenerator
+    #>
+
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [string]
+        $text,
+        
+        [ValidateRange(10,2000)]
+        [int]
+        $Width = 100,
+
+        [Switch]
+        $Show,
+
+        [string]
+        $OutPath = "$env:temp\qrcode.png",
+
+        [byte[]] 
+        $DarkColorRgba = @(0,0,0),
+
+        [byte[]]
+        $LightColorRgba = @(255,255,255)
+    )
+
+    $payload = New-Object -TypeName QRCoder.PayloadGenerator+WhatsAppMessage -ArgumentList $text
+    
+    New-PSOneQRCode -payload $payload -Show $Show -Width $Width -OutPath $OutPath -darkColorRgba $darkColorRgba -lightColorRgba $lightColorRgba
+}

--- a/QRCodeGenerator/2.6.0/New-PSOneQRCodeWifiAccess.ps1
+++ b/QRCodeGenerator/2.6.0/New-PSOneQRCodeWifiAccess.ps1
@@ -38,7 +38,7 @@
             https://github.com/TobiasPSP/Modules.QRCodeGenerator
     #>
 
-    [CmdletBinding(DefaultParameterSetName="Address")]
+    [CmdletBinding()]
     param
     (
         [Parameter(Mandatory)]

--- a/QRCodeGenerator/2.6.0/New-PSOneQRCodeWifiAccess.ps1
+++ b/QRCodeGenerator/2.6.0/New-PSOneQRCodeWifiAccess.ps1
@@ -13,6 +13,10 @@
             .PARAMETER Password
             The Wifi access point password
 
+            .PARAMETER AuthenticationMode
+            The Wifi access point Authentication Mode (nopass, WEP, WPA)
+            WPA also is WPA2
+
             .PARAMETER Width
             Height and Width of generated graphics (in pixels). Default is 100.
 
@@ -41,9 +45,12 @@
         [string]
         $SSID,
 
-        [Parameter(Mandatory)]
         [string]
         $Password,
+
+        [Parameter(Mandatory)]
+        [Authentication]
+        $AuthenticationMode,
 
         [ValidateRange(10,2000)]
         [int]
@@ -62,9 +69,16 @@
         $LightColorRgba = @(255,255,255)
     )
         
-    $payload = @"
-WIFI:S:$SSID;T:WPA2;P:$Password;;
-"@
-
+    switch ($authenticationMode) {
+        WEP { $Authentication = [QRCoder.PayloadGenerator+WiFi+Authentication]::WEP; break}
+        WPA { $Authentication = [QRCoder.PayloadGenerator+WiFi+Authentication]::WPA; break}
+        Default {
+            $Authentication =  [QRCoder.PayloadGenerator+WiFi+Authentication]::nopass
+            $password = "" 
+        }
+    }
+    
+    $payload = New-Object -TypeName QRCoder.PayloadGenerator+WiFi -ArgumentList ($SSID, $password, $Authentication)
+   
     New-PSOneQRCode -payload $payload -Show $Show -Width $Width -OutPath $OutPath -darkColorRgba $darkColorRgba -lightColorRgba $lightColorRgba
 }

--- a/QRCodeGenerator/2.6.0/Types/PSOneQRCodeAuthentication.ps1
+++ b/QRCodeGenerator/2.6.0/Types/PSOneQRCodeAuthentication.ps1
@@ -1,0 +1,8 @@
+Add-Type -TypeDefinition @"
+public enum Authentication
+{
+    nopass,
+    WEP,
+    WPA
+}
+"@

--- a/QRCodeGenerator/2.6.0/loader.psm1
+++ b/QRCodeGenerator/2.6.0/loader.psm1
@@ -7,6 +7,7 @@ $null = [System.Reflection.Assembly]::Load([System.Convert]::FromBase64String($c
 # LOADING ALL FUNCTION DEFINITIONS:
 . $PSScriptRoot\New-PSOneQRCodeVCard.ps1
 . $PSScriptRoot\New-PSOneQRCodeGeolocation.ps1
+. $PSScriptRoot\Types\PSOneQRCodeAuthentication.ps1
 . $PSScriptRoot\New-PSOneQRCodeWifiAccess.ps1
 . $PSScriptRoot\New-PSOneQRCodeTwitter.ps1
 . $PSScriptRoot\New-PSOneQRCodeText.ps1


### PR DESCRIPTION
Add all payload generators from: https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators


- [ ] BezahlCode
- [ ] Crypto Payment Address (e.g. Bitcoin, Litecoin, ...)
- [ ] Bookmark
- [ ] Calendar events (iCal/vEvent)
- [ ] ContactData (MeCard/vCard)
- [ ] Geolocation
- [ ] Girocode
- [ ] Mail
- [ ] MMS
- [ ] Monero address/payment
- [ ] One-Time-Password
- [ ] Phonenumber
- [ ] Shadowsocks configuration
- [ ] Skype call
- [ ] Slovenian QR Code for UPN QR Forms
- [ ] SMS
- [ ] SwissQrCode (ISO-20022)
- [ ] URL
- [x] WhatsAppMessage
- [x] WiFi - need to be tested
- [ ] add all to the loader.ps1