### PR TITLE
Removed blank line that was adding a CRLF to URIs

### DIFF
--- a/QRCodeGenerator/2.6.0/New-PSOneQRCodeURI.ps1
+++ b/QRCodeGenerator/2.6.0/New-PSOneQRCodeURI.ps1
@@ -57,7 +57,6 @@ function New-PSOneQRCodeURI
     )
     
 $payload = @"
-
 $($URI.AbsoluteUri)
 "@
 


### PR DESCRIPTION
The blank line in that here string was causing a CRLF to be included before the URI in the resulting QR code. Most scanners ignore that, but it still shouldn't be there.